### PR TITLE
Fix web path and update docs

### DIFF
--- a/Docs/Architecture/project_structure_20250702_1152_start.md
+++ b/Docs/Architecture/project_structure_20250702_1152_start.md
@@ -1,0 +1,11 @@
+# Project Structure - 2025-07-02 11:52 UTC (Start)
+
+This document captures the repository layout at the start of the session.
+
+## Root Directory
+
+- `src/` - Cross-platform TypeScript code
+- `public/` - Static web assets
+- `HelloWord/` - React Native project
+- `Docs/` - Project documentation
+- `scripts/` - Utility scripts

--- a/Docs/Architecture/project_structure_20250702_1155_end.md
+++ b/Docs/Architecture/project_structure_20250702_1155_end.md
@@ -1,0 +1,11 @@
+# Project Structure - 2025-07-02 11:55 UTC (End)
+
+Repository layout after fixing index.html path.
+
+## Root Directory
+
+- `src/` - Cross-platform TypeScript code
+- `public/` - Static web assets
+- `HelloWord/` - React Native project
+- `Docs/` - Project documentation
+- `scripts/` - Utility scripts

--- a/Docs/Architecture/repo_structure_20250702_1152_start.mmd
+++ b/Docs/Architecture/repo_structure_20250702_1152_start.mmd
@@ -1,0 +1,9 @@
+flowchart TD
+    root((Repo Root))
+    root --> src
+    root --> public
+    root --> Docs
+    Docs --> Architecture
+    Docs --> checklists
+    root --> HelloWord
+    root --> scripts

--- a/Docs/Architecture/repo_structure_20250702_1155_end.mmd
+++ b/Docs/Architecture/repo_structure_20250702_1155_end.mmd
@@ -1,0 +1,9 @@
+flowchart TD
+    root((Repo Root))
+    root --> src
+    root --> public
+    root --> Docs
+    Docs --> Architecture
+    Docs --> checklists
+    root --> HelloWord
+    root --> scripts

--- a/Docs/checklists/session-20250702f.md
+++ b/Docs/checklists/session-20250702f.md
@@ -1,0 +1,6 @@
+# Session Checklist (2025-07-02 F)
+
+- [x] Record starting repository structure
+- [x] Install dependencies (failed due to network restrictions)
+- [x] Fix Vite index path after folder move
+- [x] Capture final repository structure

--- a/HelloWord/index.html
+++ b/HelloWord/index.html
@@ -7,6 +7,6 @@
 </head>
 <body>
   <div id="root"></div>
-  <script type="module" src="/src/platforms/web/main.tsx"></script>
+  <script type="module" src="/HelloWord/src/platforms/web/main.tsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix absolute path to web entry file
- add architecture snapshots for start and end of session
- log tasks in a new checklist

## Testing
- `npx vite build` *(fails: module externalization errors)*

------
https://chatgpt.com/codex/tasks/task_e_68651beaef648323a449cea771890379