### PR TITLE
Remove placeholder texts and add breviary access

### DIFF
--- a/HelloWord/App.tsx
+++ b/HelloWord/App.tsx
@@ -8,6 +8,9 @@ import {
   ActivityIndicator,
   StatusBar,
   useColorScheme,
+  Button,
+  TextInput,
+  ScrollView,
 } from 'react-native';
 
 import { DataManager } from '../src/core/services/dataManager';
@@ -27,6 +30,17 @@ function App(): React.JSX.Element {
   const [error, setError] = useState<string | null>(null);
   const [calendarDays, setCalendarDays] = useState<CalendarDayItem[]>([]);
   const [dataManager, setDataManager] = useState<DataManager | null>(null);
+  const [officeTexts, setOfficeTexts] = useState<any[]>([]);
+  const [showOffice, setShowOffice] = useState<boolean>(false);
+  const [selectedDate, setSelectedDate] = useState<string>(new Date().toISOString().split('T')[0]);
+  const [selectedHour, setSelectedHour] = useState<string>('Laudes');
+
+  const loadOfficeTexts = async () => {
+    if (!dataManager) return;
+    const texts = await dataManager.getOfficeTextsForDate(selectedDate, selectedHour);
+    setOfficeTexts(texts);
+    setShowOffice(true);
+  };
 
   useEffect(() => {
     let isMounted = true; // Flag to prevent state updates if component is unmounted
@@ -116,6 +130,30 @@ function App(): React.JSX.Element {
       <View style={styles.headerContainer}>
         <Text style={[styles.headerText, textStyle]}>Liturgical Calendar (Fixed Feasts)</Text>
       </View>
+      <View style={styles.officeControls}>
+        <TextInput
+          style={styles.dateInput}
+          value={selectedDate}
+          onChangeText={setSelectedDate}
+        />
+        <TextInput
+          style={styles.hourInput}
+          value={selectedHour}
+          onChangeText={setSelectedHour}
+        />
+        <Button title="Show Breviary" onPress={loadOfficeTexts} />
+      </View>
+      {showOffice && (
+        <ScrollView style={styles.officeContainer}>
+          {officeTexts.map((t, idx) => (
+            <View key={idx} style={styles.officeItem}>
+              <Text style={styles.officePart}>{t.hour} - {t.part_type}</Text>
+              {t.latin ? <Text>{t.latin}</Text> : null}
+              {t.english ? <Text>{t.english}</Text> : null}
+            </View>
+          ))}
+        </ScrollView>
+      )}
       {calendarDays.length === 0 && !isLoading ? (
          <View style={styles.container}>
             <Text style={[styles.itemText, textStyle]}>No calendar data found. Database might be empty or import failed.</Text>
@@ -169,6 +207,35 @@ const styles = StyleSheet.create({
   },
   itemText: {
     fontSize: 16,
+  },
+  officeControls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 10,
+  },
+  dateInput: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 5,
+    marginRight: 5,
+    flex: 1,
+  },
+  hourInput: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 5,
+    marginRight: 5,
+    width: 80,
+  },
+  officeContainer: {
+    maxHeight: 200,
+    marginVertical: 10,
+  },
+  officeItem: {
+    marginBottom: 10,
+  },
+  officePart: {
+    fontWeight: 'bold',
   },
 });
 

--- a/docs/architecture/project_structure_20250706_0459_start.md
+++ b/docs/architecture/project_structure_20250706_0459_start.md
@@ -1,0 +1,35 @@
+# Project Structure - 2025-07-06 04:59 UTC (Start)
+
+This snapshot records the repository layout before implementing placeholder removal.
+
+## Root Directory
+- `BUILD_SYSTEM_LEARNINGS.md`
+- `CLAUDE.md`
+- `Docs`
+- `HelloWord`
+- `README.md`
+- `RESUME_NOTES_27JUN2025.md`
+- `ROADMAP.md`
+- `docs`
+- `package-lock.json`
+- `package.json`
+- `public`
+- `scripts`
+- `src`
+- `tailwind.config.js`
+- `test-output`
+- `tsconfig.json`
+- `vite.config.ts`
+- `yarn.lock`
+
+## Visual Representation (Mermaid)
+```mermaid
+flowchart TD
+    root --> Docs
+    root --> HelloWord
+    root --> docs
+    root --> public
+    root --> scripts
+    root --> src
+    root --> test-output
+```

--- a/docs/architecture/project_structure_20250706_0501_end.md
+++ b/docs/architecture/project_structure_20250706_0501_end.md
@@ -1,0 +1,35 @@
+# Project Structure - 2025-07-06 05:02 UTC (End)
+
+Repository layout after implementing breviary button and removing placeholders.
+
+## Root Directory
+- `BUILD_SYSTEM_LEARNINGS.md`
+- `CLAUDE.md`
+- `Docs`
+- `HelloWord`
+- `README.md`
+- `RESUME_NOTES_27JUN2025.md`
+- `ROADMAP.md`
+- `docs`
+- `package-lock.json`
+- `package.json`
+- `public`
+- `scripts`
+- `src`
+- `tailwind.config.js`
+- `test-output`
+- `tsconfig.json`
+- `vite.config.ts`
+- `yarn.lock`
+
+## Visual Representation (Mermaid)
+```mermaid
+flowchart TD
+    root --> Docs
+    root --> HelloWord
+    root --> docs
+    root --> public
+    root --> scripts
+    root --> src
+    root --> test-output
+```

--- a/docs/architecture/project_structure_20250706_0550_end.md
+++ b/docs/architecture/project_structure_20250706_0550_end.md
@@ -1,0 +1,37 @@
+# Project Structure - 2025-07-06 05:50 UTC (End)
+
+Repository layout after updating Vite config to open the correct HTML file.
+
+## Root Directory
+- `BUILD_SYSTEM_LEARNINGS.md`
+- `CLAUDE.md`
+- `Docs`
+- `HelloWord`
+- `README.md`
+- `RESUME_NOTES_27JUN2025.md`
+- `ROADMAP.md`
+- `docs`
+- `node_modules`
+- `package-lock.json`
+- `package.json`
+- `public`
+- `scripts`
+- `src`
+- `tailwind.config.js`
+- `test-output`
+- `tsconfig.json`
+- `vite.config.ts`
+- `yarn.lock`
+
+## Visual Representation (Mermaid)
+```mermaid
+flowchart TD
+    root --> Docs
+    root --> HelloWord
+    root --> docs
+    root --> node_modules
+    root --> public
+    root --> scripts
+    root --> src
+    root --> test-output
+```

--- a/docs/architecture/project_structure_20250706_0550_start.md
+++ b/docs/architecture/project_structure_20250706_0550_start.md
@@ -1,0 +1,37 @@
+# Project Structure - 2025-07-06 05:50 UTC (Start)
+
+This snapshot captures the repository layout before fixing the dev server 404 issue.
+
+## Root Directory
+- `BUILD_SYSTEM_LEARNINGS.md`
+- `CLAUDE.md`
+- `Docs`
+- `HelloWord`
+- `README.md`
+- `RESUME_NOTES_27JUN2025.md`
+- `ROADMAP.md`
+- `docs`
+- `node_modules`
+- `package-lock.json`
+- `package.json`
+- `public`
+- `scripts`
+- `src`
+- `tailwind.config.js`
+- `test-output`
+- `tsconfig.json`
+- `vite.config.ts`
+- `yarn.lock`
+
+## Visual Representation (Mermaid)
+```mermaid
+flowchart TD
+    root --> Docs
+    root --> HelloWord
+    root --> docs
+    root --> node_modules
+    root --> public
+    root --> scripts
+    root --> src
+    root --> test-output
+```

--- a/docs/checklists/session-20250706-dev-404-fix.md
+++ b/docs/checklists/session-20250706-dev-404-fix.md
@@ -1,0 +1,6 @@
+# Session Checklist (2025-07-06 Fix Dev 404)
+
+- [x] Record starting project structure
+- [x] Update `vite.config.ts` to open correct index
+- [x] Record final project structure
+- [x] Run `npm run test-liturgical` *(fails: module not found)*

--- a/docs/checklists/session-20250706-placeholder-removal.md
+++ b/docs/checklists/session-20250706-placeholder-removal.md
@@ -1,0 +1,8 @@
+# Session Checklist (2025-07-06)
+
+- [x] Update architecture snapshot before changes
+- [x] Remove placeholder mass text generation
+- [x] Remove remote file parser dependencies
+- [x] Add breviary access button
+- [x] Update architecture snapshot after changes
+- [x] Run tests

--- a/src/core/services/dataManager.ts
+++ b/src/core/services/dataManager.ts
@@ -1,7 +1,7 @@
 // Imports
 import { IStorageService } from '../types/services';
 import { CalendarService, KalendarDayInfo } from './CalendarService';
-import { TextParsingService, LiturgicalTextPart, LiturgicalContext } from './TextParsingService';
+import { LiturgicalTextPart } from './TextParsingService';
 import { DirectoriumService } from './DirectoriumService';
 import { LiturgicalEngineService, OfficeComponentPaths } from './LiturgicalEngineService';
 
@@ -64,7 +64,6 @@ interface MergedTextPart {
 export class DataManager {
   private storageService: IStorageService;
   private calendarService: CalendarService;
-  private textParserService: TextParsingService;
   private directoriumService: DirectoriumService;
   private liturgicalEngineService: LiturgicalEngineService;
   private currentLiturgicalVersionId: string = "Rubrics 1960 - 1960";
@@ -72,7 +71,6 @@ export class DataManager {
   constructor(storageService: IStorageService) {
     this.storageService = storageService;
     this.calendarService = new CalendarService();
-    this.textParserService = new TextParsingService();
     this.directoriumService = new DirectoriumService();
     this.liturgicalEngineService = new LiturgicalEngineService(this.directoriumService);
   }

--- a/src/core/services/textService.ts
+++ b/src/core/services/textService.ts
@@ -1,48 +1,19 @@
 import { BilingualText } from '../types/liturgical';
-import { IStorageService } from '../types/services';
+import { DataManager } from './dataManager';
 
 export class TextService {
-  private storageService: IStorageService;
+  private dataManager: DataManager;
 
-  constructor(storageService: IStorageService) {
-    this.storageService = storageService;
+  constructor(dataManager: DataManager) {
+    this.dataManager = dataManager;
   }
 
   async getMassProper(date: string): Promise<BilingualText[]> {
-    // This is a placeholder implementation.
-    // In a real scenario, this method would query the database
-    // based on the liturgical day's celebration.
-    console.log(`Fetching Mass Proper for date: ${date} using ${this.storageService}`);
-
-    // Example SQL (actual query would depend on the schema and celebration)
-    // const query = `
-    //   SELECT latin, english, is_rubric
-    //   FROM mass_texts
-    //   WHERE celebration_key = (SELECT celebration_key FROM calendar_days WHERE date = ?)
-    //   ORDER BY sequence;
-    // `;
-    // const params = [date];
-    // const results = await this.storageService.executeQuery(query, params);
-    // return results.map(row => ({
-    //   latin: row.latin,
-    //   english: row.english,
-    //   isRubric: !!row.is_rubric,
-    // }));
-
-    // Placeholder data:
-    if (date === '2025-06-21') {
-      return [
-        { latin: "Introitus", english: "Introit", isRubric: true },
-        { latin: "Deus, in nómine tuo salvum me fac...", english: "O God, by your name save me...", isRubric: false },
-        { latin: "Oratio", english: "Collect", isRubric: true },
-        { latin: "Deus, qui beátum Aloísium...", english: "O God, who in blessed Aloysius...", isRubric: false },
-        // ... more parts of the Mass
-      ];
-    }
-
-    return [
-      { latin: "Introitus Placeholder", english: "Introit Placeholder", isRubric: true },
-      { latin: "Lorem ipsum dolor sit amet...", english: "Placeholder text...", isRubric: false },
-    ];
+    const results = await this.dataManager.getMassTextsForDate(date);
+    return results.map(row => ({
+      latin: row.latin,
+      english: row.english,
+      isRubric: !!row.is_rubric,
+    }));
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -67,7 +67,8 @@ export default defineConfig({
   server: {
     port: 5173,
     host: '0.0.0.0',
-    open: true
+    // Open the correct entry HTML to avoid 404 on start
+    open: '/HelloWord/index.html'
   },
   define: {
     'process.env': {},


### PR DESCRIPTION
## Summary
- document project structure before/after changes
- remove placeholder mass text logic and rely on database
- drop unused TextParsingService from DataManager
- add breviary access UI in native app

## Testing
- `npm run test-liturgical` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a01a1e6c48323b90f938d91f76a21